### PR TITLE
Sanity content fixes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,8 @@ on:
     branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
+  repository_dispatch:
+    types: [content-update]
 
 # Allow this job to clone the repo and create a page deployment
 permissions:

--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -1,0 +1,19 @@
+---
+import { Image } from "astro:assets"
+const { imageUrls } = Astro.props
+---
+
+<div class="carousel">
+    <div class="slides">
+        <!-- Images -->
+        {
+            imageUrls.map((url: string) => {
+                return (<div class="slide">
+                    <Image src={url} height={450} width={800} alt="" />;
+                </div>)
+            })
+        }
+    </div>
+    <button class="prev">←</button>
+    <button class="next">→</button>
+</div>

--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -1,8 +1,8 @@
 ---
-import { Image } from "astro:assets";
 import { PortableText } from "astro-portabletext";
 import imageUrlBuilder from "@sanity/image-url";
 import { sanityClient } from "sanity:client";
+import Carousel from "./Carousel.astro";
 const builder = imageUrlBuilder(sanityClient);
 
 const { project } = Astro.props;
@@ -10,25 +10,19 @@ const { project } = Astro.props;
 const urlFor = (source) => {
     return builder.image(source);
 };
-const imageUrls: string[] = project.image.map((source) => urlFor(source).url());
+let imageUrls:string[] = []
+if(project.image && project.image.length) {
+    for(const source of project.image) {
+        if (source.asset != undefined) {
+            imageUrls.push(urlFor(source).url())
+        }
+    }
+}
 ---
 
 <section class="project">
     <h4>{project.title}</h4>
     <p class="year">{project.year}</p>
-    <div class="carousel">
-        <div class="slides">
-            <!-- Images -->
-            {
-                imageUrls.map((url) => {
-                    return (<div class="slide">
-                        <Image src={url} height={450} width={800} alt="" />;
-                    </div>)
-                })
-            }
-        </div>
-        <button class="prev">←</button>
-        <button class="next">→</button>
-    </div>
+    <Carousel imageUrls={imageUrls} />
     <PortableText value={project.description} />
 </section>

--- a/src/components/Research.astro
+++ b/src/components/Research.astro
@@ -1,17 +1,29 @@
 ---
 import { Image } from "astro:assets";
 import { PortableText } from "astro-portabletext";
-// import imageUrlBuilder from "@sanity/image-url";
-// import { sanityClient } from "sanity:client";
-// const builder = imageUrlBuilder(sanityClient);
+import imageUrlBuilder from "@sanity/image-url";
+import { sanityClient } from "sanity:client";
+import Carousel from "./Carousel.astro";
+const builder = imageUrlBuilder(sanityClient);
+
 
 const {research} = Astro.props;
+console.log(research.image)
+
+const urlFor = (source) => {
+    return builder.image(source);
+};
+let imageUrls:string[] = []
+if(research.image && research.image.length) {
+    imageUrls = research.image.map((source) => urlFor(source).url());
+}
 ---
 <section class="box">
     <h3>{research.title}</h3>
     { research.subtitle && <h4 class="location">{research.subtitle}</h4>}
     { research.institution && <h4 class="location">{research.institution}</h4>}
     <section class="content">
+        {imageUrls.length > 0 && <Carousel imageUrls={imageUrls} />}
         <PortableText 
             value={research.text}
         />

--- a/src/components/Research.astro
+++ b/src/components/Research.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from "astro:assets";
 import { PortableText } from "astro-portabletext";
 import imageUrlBuilder from "@sanity/image-url";
 import { sanityClient } from "sanity:client";
@@ -8,14 +7,18 @@ const builder = imageUrlBuilder(sanityClient);
 
 
 const {research} = Astro.props;
-console.log(research.image)
 
 const urlFor = (source) => {
     return builder.image(source);
 };
+
 let imageUrls:string[] = []
 if(research.image && research.image.length) {
-    imageUrls = research.image.map((source) => urlFor(source).url());
+    for(const source of research.image) {
+        if (source.asset != undefined) {
+            imageUrls.push(urlFor(source).url())
+        }
+    }
 }
 ---
 <section class="box">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,10 +7,10 @@ import Header from '../components/Header.astro';
 
 const projects = await sanityClient.fetch('*[_type == "project"]')
 const research = await sanityClient.fetch('*[_type == "research"]')
-const settings = await sanityClient.fetch('*[_type == "siteSettings"][0]')
-Object.keys(settings).forEach(key => {
-	console.log(key)
-})
+// const settings = await sanityClient.fetch('*[_type == "siteSettings"][0]')
+// Object.keys(settings).forEach(key => {
+// 	console.log(key)
+// })
 // colour names in settings
 // mainBgCol
 // accentCol

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import Image from 'astro/components/Image.astro';
 import { sanityClient } from "sanity:client";
 import Project from '../components/Project.astro';
 import Research from '../components/Research.astro';


### PR DESCRIPTION
moves the carousel into its own component `Carousel.astro` for reusability. As props it simply takes an array of image urls.

closes #23 and #25 

carousel component has been reused from the project side so it might not work perfectly inside of the box on the research side; currently there aren't any images to test this with though.

This also makes a change to the workflow file to allow for updating via webhook but this needs further config in settings